### PR TITLE
Go to BEG before inserting text

### DIFF
--- a/evil-replace-with-register.el
+++ b/evil-replace-with-register.el
@@ -68,6 +68,7 @@
   (let ((text (if register
                   (evil-get-register register)
                 (current-kill 0))))
+    (goto-char beg)
     (if (eq type 'block)
         (evil-apply-on-block
          (lambda (begcol endcol)
@@ -78,7 +79,7 @@
                      (end (evil-move-to-column endcol nil t)))
                  (delete-region beg end)
                  (dotimes (_ count)
-                   (insert text)))))) 
+                   (insert text))))))
          beg end t)
       (delete-region beg end)
       (dotimes (_ count)


### PR DESCRIPTION
Make sure the cursor is on BEG before calling 'insert. Some text objects like `i"` allow specifying the range without placing the cursor on BEG, as a result `delete-region` deletes the correct region, but `insert` insert text at the wrong position